### PR TITLE
add macro defhookfn

### DIFF
--- a/src/hook-util.lisp
+++ b/src/hook-util.lisp
@@ -18,10 +18,7 @@ livecoding.
                 (type wparam ,wparam)
                 (type lparam ,lparam)
                 (ignorable ,ncode ,wparam ,lparam))
-       (flet ((call-next-hook ()
-                (win32:call-next-hook-ex (cffi:null-pointer) ,ncode ,wparam ,lparam)))
-         (declare (ignorable #'call-next-hook))
-         ,@body))
+       ,@body)
      ;; There's no way to check if the callback is already defined
      ;; But `cffi:get-callback' will signal an error if it doesn't exist
      (handler-case

--- a/src/hook-util.lisp
+++ b/src/hook-util.lisp
@@ -1,0 +1,46 @@
+(in-package #:com.inuoe.winutil)
+
+(defmacro defhookfn (name (ncode wparam lparam) &body body)
+  "Utility Wrapper around `cffi:defcallback' for defining hook callbacks.
+Defines a `cffi:callback' with appropriate signature, a well as a
+regular `defun'.  The callback shall not be redefined on repeated
+evaluation, but instead the `defun' will, allowing for better
+livecoding.
+
+`name' - The name of the callback and function
+`ncode' - Symbol bound to the ncode parameter
+`wparam' - Symbol bound to the wparam parameter
+`lparam' - Symbol bound to the lparam parameter
+"
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (defun ,name (,ncode ,wparam ,lparam)
+       (declare (type (signed-byte #.(* 8 (cffi:foreign-type-size :int))) ,ncode)
+                (type wparam ,wparam)
+                (type lparam ,lparam)
+                (ignorable ,ncode ,wparam ,lparam))
+       (flet ((call-next-hook ()
+                (win32:call-next-hook-ex (cffi:null-pointer) ,ncode ,wparam ,lparam)))
+         (declare (ignorable #'call-next-hook))
+         ,@body))
+     ;; There's no way to check if the callback is already defined
+     ;; But `cffi:get-callback' will signal an error if it doesn't exist
+     (handler-case
+         (cffi:get-callback ',name)
+       (error ()
+         (cffi:defcallback (,name :convention :stdcall) win32:lresult
+             ((,ncode :int)
+              (,wparam win32:wparam) (,lparam win32:lparam))
+           (prog ()
+            retry
+              (restart-case
+                  (let ((ret (,name ,ncode ,wparam ,lparam)))
+                    (unless (typep ret 'lresult)
+                      (error 'type-error :datum ret :expected-type 'lresult))
+                    (return ret))
+                (retry-proc ()
+                  :report ,(format nil "Retry calling the ll-keyboard-proc (~A)." name)
+                  (go retry))
+                (call-next-hook ()
+                  :report "Invoke `win32:call-next-hook-ex'"
+                  (return (win32:call-next-hook-ex (cffi:null-pointer) ,ncode ,wparam ,lparam))))))))
+     ',name))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -36,6 +36,7 @@
    #:lparam
    #:lresult
    #:defwndproc
+   #:define-ll-keyboard-proc
    #:message-pump
 
    #:hicon

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -36,7 +36,7 @@
    #:lparam
    #:lresult
    #:defwndproc
-   #:define-ll-keyboard-proc
+   #:defhookfn
    #:message-pump
 
    #:hicon

--- a/src/ui-util.lisp
+++ b/src/ui-util.lisp
@@ -191,51 +191,6 @@ The callback shall not be redefined on repeated evaluation, but instead the `def
                   (return (win32:call-next-hook-ex (cffi:null-pointer) ,code ,wparam ,msg))))))))
      ',name))
 
-
-(defmacro define-ll-keyboard-proc (name (ncode wparam lparam) &body body)
-  "Utility Wrapper around `cffi:defcallback' for defining LowLevelKeyboardProc callbacks.
-Defines a `cffi:callback' with appropriate signature, a well as a
-regular `defun'.  The callback shall not be redefined on repeated
-evaluation, but instead the `defun' will, allowing for better
-livecoding.
-
-`name' - The name of the callback and function
-`ncode' - Symbol bound to the ncode parameter
-`wparam' - Symbol bound to the wparam parameter
-`lparam' - Symbol bound to the lparam parameter
-
-https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)
-"
-  `(eval-when (:compile-toplevel :load-toplevel :execute)
-     (defun ,name (,ncode ,wparam ,lparam)
-       (declare (type (signed-byte #.(* 8 (cffi:foreign-type-size :int))) ,ncode)
-                (type wparam ,wparam)
-                (type lparam ,lparam)
-                (ignorable ,ncode ,wparam ,lparam))
-       ,@body)
-     ;; There's no way to check if the callback is already defined
-     ;; But `cffi:get-callback' will signal an error if it doesn't exist
-     (handler-case
-         (cffi:get-callback ',name)
-       (error ()
-         (cffi:defcallback (,name :convention :stdcall) win32:lresult
-             ((,ncode :int)
-              (,wparam win32:wparam) (,lparam win32:lparam))
-           (prog ()
-            retry
-              (restart-case
-                  (let ((ret (,name ,ncode ,wparam ,lparam)))
-                    (unless (typep ret 'lresult)
-                      (error 'type-error :datum ret :expected-type 'lresult))
-                    (return ret))
-                (retry-proc ()
-                  :report ,(format nil "Retry calling the ll-keyboard-proc (~A)." name)
-                  (go retry))
-                (call-next-hook ()
-                  :report "Invoke `win32:call-next-hook-ex'"
-                  (return (win32:call-next-hook-ex (cffi:null-pointer) ,ncode ,wparam ,lparam))))))))
-     ',name))
-
 (defun message-pump ()
   "Run a typical win32 message pump until quit."
   (cffi:with-foreign-object (msg 'win32:msg)

--- a/src/ui-util.lisp
+++ b/src/ui-util.lisp
@@ -191,6 +191,51 @@ The callback shall not be redefined on repeated evaluation, but instead the `def
                   (return (win32:call-next-hook-ex (cffi:null-pointer) ,code ,wparam ,msg))))))))
      ',name))
 
+
+(defmacro define-ll-keyboard-proc (name (ncode wparam lparam) &body body)
+  "Utility Wrapper around `cffi:defcallback' for defining LowLevelKeyboardProc callbacks.
+Defines a `cffi:callback' with appropriate signature, a well as a
+regular `defun'.  The callback shall not be redefined on repeated
+evaluation, but instead the `defun' will, allowing for better
+livecoding.
+
+`name' - The name of the callback and function
+`ncode' - Symbol bound to the ncode parameter
+`wparam' - Symbol bound to the wparam parameter
+`lparam' - Symbol bound to the lparam parameter
+
+https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms644985(v=vs.85)
+"
+  `(eval-when (:compile-toplevel :load-toplevel :execute)
+     (defun ,name (,ncode ,wparam ,lparam)
+       (declare (type (signed-byte #.(* 8 (cffi:foreign-type-size :int))) ,ncode)
+                (type wparam ,wparam)
+                (type lparam ,lparam)
+                (ignorable ,ncode ,wparam ,lparam))
+       ,@body)
+     ;; There's no way to check if the callback is already defined
+     ;; But `cffi:get-callback' will signal an error if it doesn't exist
+     (handler-case
+         (cffi:get-callback ',name)
+       (error ()
+         (cffi:defcallback (,name :convention :stdcall) win32:lresult
+             ((,ncode :int)
+              (,wparam win32:wparam) (,lparam win32:lparam))
+           (prog ()
+            retry
+              (restart-case
+                  (let ((ret (,name ,ncode ,wparam ,lparam)))
+                    (unless (typep ret 'lresult)
+                      (error 'type-error :datum ret :expected-type 'lresult))
+                    (return ret))
+                (retry-proc ()
+                  :report ,(format nil "Retry calling the ll-keyboard-proc (~A)." name)
+                  (go retry))
+                (call-next-hook ()
+                  :report "Invoke `win32:call-next-hook-ex'"
+                  (return (win32:call-next-hook-ex (cffi:null-pointer) ,ncode ,wparam ,lparam))))))))
+     ',name))
+
 (defun message-pump ()
   "Run a typical win32 message pump until quit."
   (cffi:with-foreign-object (msg 'win32:msg)


### PR DESCRIPTION
- [x] ~~**I haven't tested it yet**~~ Tested
- [x] I made sure there are no errors or warnings when compiling the macro itself and when you compile `(define-ll-keyboard-proc ll-kbd-callback (ncode wparam lparam))`
- [x] Feel free to ask for changes (like the name)
- [x] remove `flet ((call-next-hook`

[Related changes in win32](https://github.com/Zulu-Inuoe/win32/pull/5/files#diff-551c33bbd0758a2d6d82f72df1fa8371a9e7ac0e4873e3ba7780913b6a296e31R324-R330)